### PR TITLE
Fix/zip length and multiline hint

### DIFF
--- a/app/src/main/java/co/condorlabs/customcomponents/customedittext/BaseEditTextFormField.kt
+++ b/app/src/main/java/co/condorlabs/customcomponents/customedittext/BaseEditTextFormField.kt
@@ -36,6 +36,7 @@ import co.condorlabs.customcomponents.formfield.ValidationResult
 import com.google.android.material.textfield.TextInputLayout
 import java.util.regex.Pattern
 
+
 /**
  * @author Oscar Gallon on 2/26/19.
  */
@@ -70,6 +71,7 @@ open class BaseEditTextFormField(context: Context, attrs: AttributeSet) :
     )
     private var showValidationIcon: Boolean = false
     private var textWatcher: DefaultTextWatcher? = null
+    private var maxCharacters: Int? = null
     protected val regexListToMatch = HashSet<String>()
 
     init {
@@ -78,7 +80,6 @@ open class BaseEditTextFormField(context: Context, attrs: AttributeSet) :
             R.styleable.BaseEditTextFormField,
             DEFAULT_STYLE_ATTR, DEFAULT_STYLE_RES
         )
-        textInputLayout?.gravity = Gravity.TOP
 
         hint = typedArray.getString(R.styleable.BaseEditTextFormField_hint)
             ?: context.getString(R.string.default_base_hint)
@@ -101,7 +102,8 @@ open class BaseEditTextFormField(context: Context, attrs: AttributeSet) :
         placeholder = typedArray.getString(R.styleable.BaseEditTextFormField_placeholder)
         showValidationIcon =
             typedArray.getBoolean(R.styleable.BaseEditTextFormField_show_validation_icon, false)
-
+        maxCharacters =
+            typedArray.getString(R.styleable.BaseEditTextFormField_max_characters)?.toInt()
         typedArray.recycle()
 
         regex?.let {
@@ -139,11 +141,14 @@ open class BaseEditTextFormField(context: Context, attrs: AttributeSet) :
         val wrappedTextInputLayout = textInputLayout ?: return
         val wrappedEditText = editText?.let { it } ?: return
 
-        wrappedEditText.onFocusChangeListener = this
-        wrappedEditText.hint = this@BaseEditTextFormField.hint
-        wrappedEditText.gravity = Gravity.TOP
+        wrappedEditText.run {
+            onFocusChangeListener = this@BaseEditTextFormField
+            hint = this@BaseEditTextFormField.hint
+            gravity = Gravity.TOP
+            maxCharacters?.let {
+                filters = arrayOf<InputFilter>(InputFilter.LengthFilter(it))
+            }
 
-        wrappedEditText.apply {
             id = View.generateViewId()
             setTextSize(TypedValue.COMPLEX_UNIT_PX, context.resources.getDimension(R.dimen.body))
             isMultiline(wrappedEditText)

--- a/app/src/main/java/co/condorlabs/customcomponents/customedittext/BaseEditTextFormField.kt
+++ b/app/src/main/java/co/condorlabs/customcomponents/customedittext/BaseEditTextFormField.kt
@@ -23,6 +23,7 @@ import android.text.InputType
 import android.text.method.DigitsKeyListener
 import android.util.AttributeSet
 import android.util.TypedValue
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.EditText
@@ -77,6 +78,7 @@ open class BaseEditTextFormField(context: Context, attrs: AttributeSet) :
             R.styleable.BaseEditTextFormField,
             DEFAULT_STYLE_ATTR, DEFAULT_STYLE_RES
         )
+        textInputLayout?.gravity = Gravity.TOP
 
         hint = typedArray.getString(R.styleable.BaseEditTextFormField_hint)
             ?: context.getString(R.string.default_base_hint)
@@ -138,7 +140,8 @@ open class BaseEditTextFormField(context: Context, attrs: AttributeSet) :
         val wrappedEditText = editText?.let { it } ?: return
 
         wrappedEditText.onFocusChangeListener = this
-        wrappedTextInputLayout.hint = this@BaseEditTextFormField.hint
+        wrappedEditText.hint = this@BaseEditTextFormField.hint
+        wrappedEditText.gravity = Gravity.TOP
 
         wrappedEditText.apply {
             id = View.generateViewId()
@@ -271,6 +274,8 @@ open class BaseEditTextFormField(context: Context, attrs: AttributeSet) :
         textInputLayout?.editText?.postDelayed({
             textInputLayout?.editText?.hint = placeholder ?: EMPTY
         }, MILLISECONDS_TO_SHOW_PLACE_HOLDER)
+        textInputLayout?.hint = this@BaseEditTextFormField.hint
+        textInputLayout?.editText?.hint = null
     }
 
     private fun hidePlaceholder() {

--- a/app/src/main/java/co/condorlabs/customcomponents/customedittext/BaseEditTextFormField.kt
+++ b/app/src/main/java/co/condorlabs/customcomponents/customedittext/BaseEditTextFormField.kt
@@ -36,7 +36,6 @@ import co.condorlabs.customcomponents.formfield.ValidationResult
 import com.google.android.material.textfield.TextInputLayout
 import java.util.regex.Pattern
 
-
 /**
  * @author Oscar Gallon on 2/26/19.
  */

--- a/app/src/main/java/co/condorlabs/customcomponents/customedittext/readme.md
+++ b/app/src/main/java/co/condorlabs/customcomponents/customedittext/readme.md
@@ -32,6 +32,7 @@ Emerald provides this component to be used as EditText
 | app:max_lines | Maximum number of lines|
 | app:min_lines | Minimum number of lines|
 | app:multiline | Will the field display more than one line|
+| app:max_characters | Maximum number of characters|
 
 ## Public methods
 | Return Type | Description |

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -36,6 +36,7 @@
         <attr name="placeholder" format="string" />
         <attr name="show_validation_icon" format="boolean"/>
         <attr name="digits" format="string" />
+        <attr name="max_characters" format="integer" />
     </declare-styleable>
 
     <declare-styleable name="SpinnerFormField">

--- a/test/src/androidTest/java/co/condorlabs/customcomponents/test/BaseEditTextFieldTest.kt
+++ b/test/src/androidTest/java/co/condorlabs/customcomponents/test/BaseEditTextFieldTest.kt
@@ -38,7 +38,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class BaseEditTextFieldTest : MockActivityTest() {
 
-    @SmallTest
+   /* @SmallTest
     @Test
     fun shouldDisplayDefaultHint() {
         MockActivity.layout = R.layout.activity_baseedittextfield_test
@@ -66,7 +66,7 @@ class BaseEditTextFieldTest : MockActivityTest() {
 
         // Then
         Assert.assertEquals("Zip", formField?.hint)
-    }
+    }*/
 
     @SmallTest
     @Test
@@ -86,7 +86,7 @@ class BaseEditTextFieldTest : MockActivityTest() {
         isTextInLines(3)
     }
 
-    @SmallTest
+   /* @SmallTest
     @Test
     fun shouldNotBeInvalidIfItsNotRequired() {
         MockActivity.layout = R.layout.activity_baseedittext_no_required_test
@@ -586,5 +586,5 @@ class BaseEditTextFieldTest : MockActivityTest() {
 
         // Then
         Assert.assertEquals("123?AB", result)
-    }
+    }*/
 }

--- a/test/src/androidTest/java/co/condorlabs/customcomponents/test/BaseEditTextFieldTest.kt
+++ b/test/src/androidTest/java/co/condorlabs/customcomponents/test/BaseEditTextFieldTest.kt
@@ -208,7 +208,7 @@ class BaseEditTextFieldTest : MockActivityTest() {
 
     @SmallTest
     @Test
-    fun shouldNotTypeMoreCharacyersThanTheRegexAllow() {
+    fun shouldNotTypeMoreCharactersThanTheRegexAllow() {
         MockActivity.layout = R.layout.activity_baseedittextfield_with_hint_test
         restartActivity()
 
@@ -224,7 +224,7 @@ class BaseEditTextFieldTest : MockActivityTest() {
         val result = formField.isValid()
 
         // Then
-        Espresso.onView(ViewMatchers.withText("123456789")).check(matches(isDisplayed()))
+        Espresso.onView(withText("123456789")).check(matches(isDisplayed()))
         Assert.assertTrue(result.isValid)
     }
 
@@ -324,7 +324,7 @@ class BaseEditTextFieldTest : MockActivityTest() {
         editText.perform(typeText("12345"))
 
         // Then
-        Assert.assertNotNull(realEditText!!.compoundDrawables[2])
+        Assert.assertNotNull(realEditText.compoundDrawables[2])
     }
 
     @SmallTest
@@ -600,7 +600,7 @@ class BaseEditTextFieldTest : MockActivityTest() {
 
     @SmallTest
     @Test
-    fun shoulAcceptOnlyTheSpecifiedCharacters() {
+    fun shouldAcceptOnlyTheSpecifiedCharacters() {
         MockActivity.layout = R.layout.activity_baseedittext_with_digits
         restartActivity()
 

--- a/test/src/androidTest/java/co/condorlabs/customcomponents/test/BaseEditTextFieldTest.kt
+++ b/test/src/androidTest/java/co/condorlabs/customcomponents/test/BaseEditTextFieldTest.kt
@@ -38,7 +38,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class BaseEditTextFieldTest : MockActivityTest() {
 
-   /* @SmallTest
+    @SmallTest
     @Test
     fun shouldDisplayDefaultHint() {
         MockActivity.layout = R.layout.activity_baseedittextfield_test
@@ -66,7 +66,7 @@ class BaseEditTextFieldTest : MockActivityTest() {
 
         // Then
         Assert.assertEquals("Zip", formField?.hint)
-    }*/
+    }
 
     @SmallTest
     @Test
@@ -86,7 +86,7 @@ class BaseEditTextFieldTest : MockActivityTest() {
         isTextInLines(3)
     }
 
-   /* @SmallTest
+    @SmallTest
     @Test
     fun shouldNotBeInvalidIfItsNotRequired() {
         MockActivity.layout = R.layout.activity_baseedittext_no_required_test
@@ -143,7 +143,7 @@ class BaseEditTextFieldTest : MockActivityTest() {
 
     @SmallTest
     @Test
-    fun shouldOnlyAllowToTypeUntilMaxLength() {
+    fun shouldOnlyAllowToTypeUntilMaxLengthByCode() {
         MockActivity.layout = R.layout.activity_baseedittext_with_hint_and_regex_test
         restartActivity()
 
@@ -154,6 +154,29 @@ class BaseEditTextFieldTest : MockActivityTest() {
         val formField = ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.tlBase)
         formField.setIsRequired(true)
         formField.setMaxLength(5)
+
+        // When
+        editText.perform(typeText("123456"))
+        val result = formField.isValid()
+
+        // Then
+        Espresso.onView(ViewMatchers.withText("12345")).check(matches(isDisplayed()))
+        Assert.assertEquals("Zip", (formField)?.hint)
+        Assert.assertTrue(result.isValid)
+    }
+
+    @SmallTest
+    @Test
+    fun shouldOnlyAllowToTypeUntilMaxLengthByXml() {
+        MockActivity.layout = R.layout.activity_baseedittext_with_max_character
+        restartActivity()
+
+        // Given
+        val base = ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.tlBase)
+        val realEditText = base.textInputLayout!!.editText!!
+        val editText = Espresso.onView(withId(realEditText.id))
+        val formField = ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.tlBase)
+        formField.setIsRequired(true)
 
         // When
         editText.perform(typeText("123456"))
@@ -282,7 +305,7 @@ class BaseEditTextFieldTest : MockActivityTest() {
         Thread.sleep(210)
 
         // then
-       Assert.assertEquals(baseView.textInputLayout!!.editText!!.hint, "Hola")
+        Assert.assertEquals(baseView.textInputLayout!!.editText!!.hint, "Hola")
     }
 
     @SmallTest
@@ -433,7 +456,8 @@ class BaseEditTextFieldTest : MockActivityTest() {
         restartActivity()
 
         // Given
-        val formField = ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.etPasswordField)
+        val formField =
+            ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.etPasswordField)
 
         // When
         val result = formField.getInputType()
@@ -465,7 +489,8 @@ class BaseEditTextFieldTest : MockActivityTest() {
         restartActivity()
 
         // Given
-        val formField = ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.etNumberDecimalField)
+        val formField =
+            ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.etNumberDecimalField)
 
         // When
         val result = formField.getInputType()
@@ -481,7 +506,8 @@ class BaseEditTextFieldTest : MockActivityTest() {
         restartActivity()
 
         // Given
-        val formField = ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.etNumberField)
+        val formField =
+            ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.etNumberField)
 
         // When
         val result = formField.getInputType()
@@ -497,7 +523,8 @@ class BaseEditTextFieldTest : MockActivityTest() {
         restartActivity()
 
         // Given
-        val formField = ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.etTextCapCharactersField)
+        val formField =
+            ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.etTextCapCharactersField)
 
         // When
         val result = formField.getInputType()
@@ -561,7 +588,8 @@ class BaseEditTextFieldTest : MockActivityTest() {
         restartActivity()
 
         // Given
-        val formField = ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.tlBaseWithInputType)
+        val formField =
+            ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.tlBaseWithInputType)
 
         // When
         val digits = formField.getDigits()
@@ -577,7 +605,8 @@ class BaseEditTextFieldTest : MockActivityTest() {
         restartActivity()
 
         // Given
-        val formField = ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.tlBaseWithInputType)
+        val formField =
+            ruleActivity.activity.findViewById<BaseEditTextFormField>(R.id.tlBaseWithInputType)
 
         // When
         Espresso.onView(withId(formField.textInputLayout!!.editText!!.id))
@@ -586,5 +615,5 @@ class BaseEditTextFieldTest : MockActivityTest() {
 
         // Then
         Assert.assertEquals("123?AB", result)
-    }*/
+    }
 }

--- a/test/src/main/res/layout/activity_baseedittext_with_max_character.xml
+++ b/test/src/main/res/layout/activity_baseedittext_with_max_character.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2019 CondorLabs
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content">
+
+
+    <co.condorlabs.customcomponents.customedittext.BaseEditTextFormField
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/tlBase"
+            android:textSize="@dimen/body"
+            app:max_characters="5"
+            app:regex="^[0-9]{5}$"
+            app:hint="@string/zip_hint"
+            app:input_type="number"/>
+</LinearLayout>

--- a/test/src/main/res/layout/activity_baseedittextfield_multiline_test.xml
+++ b/test/src/main/res/layout/activity_baseedittextfield_multiline_test.xml
@@ -12,7 +12,6 @@
             android:id="@+id/tlBase"
             app:min_lines="5"
             app:max_lines="8"
-            app:hint="Su pinche hint"
             app:multiline="true"
             android:textSize="@dimen/body"
             app:input_type="multiline"/>

--- a/test/src/main/res/layout/activity_baseedittextfield_multiline_test.xml
+++ b/test/src/main/res/layout/activity_baseedittextfield_multiline_test.xml
@@ -12,6 +12,7 @@
             android:id="@+id/tlBase"
             app:min_lines="5"
             app:max_lines="8"
+            app:hint="Su pinche hint"
             app:multiline="true"
             android:textSize="@dimen/body"
             app:input_type="multiline"/>


### PR DESCRIPTION
fix the zip max character size by xml, and move the hint on multiline text to the top of the box
<img width="289" alt="Captura de Pantalla 2019-11-13 a la(s) 10 00 51" src="https://user-images.githubusercontent.com/45563446/68775463-85a06400-05fc-11ea-9727-e4ebd7976b7b.png">
