### PR TITLE
Fix ➤ CameraX bitmap result

### DIFF
--- a/app/src/main/java/co/condorlabs/customcomponents/Constants.kt
+++ b/app/src/main/java/co/condorlabs/customcomponents/Constants.kt
@@ -258,6 +258,3 @@ const val FILE_SELECTOR_OPTION_FILE = "File"
 
 /** FILE SELECTOR VALUES **/
 const val FILE_AFTER_DOT_INDEX = 1
-
-/** CAMERA **/
-const val CAMERA_TAKE_PHOTO_PARAM = "imageCaptured"

--- a/app/src/main/java/co/condorlabs/customcomponents/simplecamerax/CameraActivity.kt
+++ b/app/src/main/java/co/condorlabs/customcomponents/simplecamerax/CameraActivity.kt
@@ -1,7 +1,6 @@
 package co.condorlabs.customcomponents.simplecamerax
 
 import android.app.Activity
-import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Matrix
 import android.graphics.drawable.Animatable
@@ -10,12 +9,10 @@ import android.view.View
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.core.ImageCapture
-import co.condorlabs.customcomponents.CAMERA_TAKE_PHOTO_PARAM
 import co.condorlabs.customcomponents.R
 import co.condorlabs.customcomponents.models.CameraConfig
 import co.condorlabs.customcomponents.simplecamerax.fragment.SimpleCameraXFragment
 import kotlinx.android.synthetic.main.activity_camera.*
-import java.io.ByteArrayOutputStream
 
 class CameraActivity : AppCompatActivity(), SimpleCameraXFragment.OnCameraXListener {
 
@@ -53,9 +50,7 @@ class CameraActivity : AppCompatActivity(), SimpleCameraXFragment.OnCameraXListe
 
     override fun fragmentTextureViewLoaded() {
         initCameraX()
-        btnCancelPhoto?.setOnClickListener {
-            resetLayout()
-        }
+        btnCancelPhoto?.setOnClickListener { resetLayout() }
     }
 
     private fun initCameraX() {
@@ -86,13 +81,8 @@ class CameraActivity : AppCompatActivity(), SimpleCameraXFragment.OnCameraXListe
             visibility = View.VISIBLE
             setOnClickListener {
                 photoCaptured?.cropImage()?.let { bitmapResult ->
-                    val bStream = ByteArrayOutputStream()
-                    bitmapResult.compress(Bitmap.CompressFormat.JPEG, 100, bStream)
-                    val byteArray = bStream.toByteArray()
-
-                    val intent = Intent()
-                    intent.putExtra(CAMERA_TAKE_PHOTO_PARAM, byteArray)
-                    setResult(Activity.RESULT_OK, intent)
+                    CameraBitmapCache.setBitmap(bitmapResult)
+                    setResult(Activity.RESULT_OK)
                     finish()
                 }
             }
@@ -130,9 +120,7 @@ class CameraActivity : AppCompatActivity(), SimpleCameraXFragment.OnCameraXListe
         imageCaptureError: ImageCapture.ImageCaptureError,
         message: String,
         cause: Throwable?
-    ) {
-
-    }
+    ) {}
 
     override fun onBackPressed() {
         if (fabCaptureButton?.visibility == View.INVISIBLE) {

--- a/app/src/main/java/co/condorlabs/customcomponents/simplecamerax/CameraBitmapCache.kt
+++ b/app/src/main/java/co/condorlabs/customcomponents/simplecamerax/CameraBitmapCache.kt
@@ -1,0 +1,23 @@
+package co.condorlabs.customcomponents.simplecamerax
+
+import android.graphics.Bitmap
+
+/**
+ * @author Alexis Duque on 2019-12-04.
+ * @company Condor Labs.
+ * @email eduque@condorlabs.io.
+ */
+object CameraBitmapCache {
+
+    private var bitmap: Bitmap? = null
+
+    fun getBitmap(): Bitmap? {
+        val bitmapToReturn = bitmap
+        bitmap = null
+        return bitmapToReturn
+    }
+
+    fun setBitmap(bitmap: Bitmap?) {
+        this.bitmap = bitmap
+    }
+}

--- a/app/src/main/java/co/condorlabs/customcomponents/simplecamerax/README.md
+++ b/app/src/main/java/co/condorlabs/customcomponents/simplecamerax/README.md
@@ -48,9 +48,8 @@ override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) 
     super.onActivityResult(requestCode, resultCode, data)
     if (resultCode == Activity.RESULT_OK) {
         if (requestCode == CAMERA_REQUEST_CODE) {
-            data?.getByteArrayExtra(CAMERA_TAKE_PHOTO_PARAM)?.let {
-                val bitmap = BitmapFactory.decodeByteArray(it, 0, it.size)
-                myImageView.setImageBitmap(bitmap)
+            CameraBitmapCache.getBitmap()?.let { bitmapResult ->
+                // do something with the captured image...
             }
         }
     }

--- a/bintray.gradle
+++ b/bintray.gradle
@@ -23,7 +23,7 @@ android {
 }
 
 ext {
-    libraryVersion = '0.82.0'
+    libraryVersion = '0.83.0'
 
     bintrayRepo = 'CustomComponents'
     bintrayName = 'CustomComponents'

--- a/test/src/androidTest/java/co/condorlabs/customcomponents/test/simplecamerax/CameraActivityTest.kt
+++ b/test/src/androidTest/java/co/condorlabs/customcomponents/test/simplecamerax/CameraActivityTest.kt
@@ -3,7 +3,7 @@ package co.condorlabs.customcomponents.test.simplecamerax
 import android.app.Activity
 import android.content.Intent
 import android.graphics.Bitmap
-git statusimport android.os.Build
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.widget.TextView

--- a/test/src/androidTest/java/co/condorlabs/customcomponents/test/simplecamerax/CameraActivityTest.kt
+++ b/test/src/androidTest/java/co/condorlabs/customcomponents/test/simplecamerax/CameraActivityTest.kt
@@ -3,8 +3,7 @@ package co.condorlabs.customcomponents.test.simplecamerax
 import android.app.Activity
 import android.content.Intent
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.os.Build
+git statusimport android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.widget.TextView
@@ -13,7 +12,6 @@ import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.rule.ActivityTestRule
 import androidx.test.runner.AndroidJUnit4
-import co.condorlabs.customcomponents.CAMERA_TAKE_PHOTO_PARAM
 import co.condorlabs.customcomponents.custombutton.CustomButton
 import co.condorlabs.customcomponents.models.CameraConfig
 import co.condorlabs.customcomponents.simplecamerax.CameraActivity

--- a/test/src/androidTest/java/co/condorlabs/customcomponents/test/simplecamerax/CameraActivityTest.kt
+++ b/test/src/androidTest/java/co/condorlabs/customcomponents/test/simplecamerax/CameraActivityTest.kt
@@ -17,6 +17,7 @@ import co.condorlabs.customcomponents.CAMERA_TAKE_PHOTO_PARAM
 import co.condorlabs.customcomponents.custombutton.CustomButton
 import co.condorlabs.customcomponents.models.CameraConfig
 import co.condorlabs.customcomponents.simplecamerax.CameraActivity
+import co.condorlabs.customcomponents.simplecamerax.CameraBitmapCache
 import co.condorlabs.customcomponents.test.R
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import org.junit.*
@@ -84,8 +85,6 @@ class CameraActivityTest {
 
     @Test
     @LargeTest
-    @Ignore("For some reason, all test are passing in local but not are passing in Travis. " +
-            "I've run the all test in physical devices and emulators and all test are passing.")
     fun shouldReturnBitmapOnActivityResult() {
         launchActivity(
             CameraConfig(
@@ -98,15 +97,14 @@ class CameraActivityTest {
             val fabCaptureButton = ruleActivity.activity.findViewById<FloatingActionButton>(R.id.fabCaptureButton)
             val cropButton = ruleActivity.activity.findViewById<CustomButton>(R.id.btnCropPhoto)
             ruleActivity.runOnUiThread { fabCaptureButton.performClick() }
-            Thread.sleep(3000)
+            Thread.sleep(2000)
 
             // When
             ruleActivity.runOnUiThread { cropButton.performClick() }
             ruleActivity.activity.finish()
 
             // Then
-            val byteArray = ruleActivity.activityResult.resultData.getByteArrayExtra(CAMERA_TAKE_PHOTO_PARAM)
-            val bitmap: Bitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size)
+            val bitmap: Bitmap? = CameraBitmapCache.getBitmap()
             Assert.assertNotNull(bitmap)
         }
     }
@@ -118,14 +116,12 @@ class CameraActivityTest {
             CameraConfig()
         ) {
             // Given
-            val tvDescription =
-                ruleActivity.activity.findViewById<TextView>(R.id.capturePhotoDescription)
+            val tvDescription = ruleActivity.activity.findViewById<TextView>(R.id.capturePhotoDescription)
             val cancelButton = ruleActivity.activity.findViewById<CustomButton>(R.id.btnCancelPhoto)
             val cropButton = ruleActivity.activity.findViewById<CustomButton>(R.id.btnCropPhoto)
-            val fabCaptureButton =
-                ruleActivity.activity.findViewById<FloatingActionButton>(R.id.fabCaptureButton)
+            val fabCaptureButton = ruleActivity.activity.findViewById<FloatingActionButton>(R.id.fabCaptureButton)
             ruleActivity.runOnUiThread { fabCaptureButton.performClick() }
-            Thread.sleep(3000)
+            Thread.sleep(2000)
 
             // When
             ruleActivity.runOnUiThread { cancelButton.performClick() }
@@ -146,10 +142,9 @@ class CameraActivityTest {
         ) {
             // Given
             val cropButton = ruleActivity.activity.findViewById<CustomButton>(R.id.btnCropPhoto)
-            val fabCaptureButton =
-                ruleActivity.activity.findViewById<FloatingActionButton>(R.id.fabCaptureButton)
+            val fabCaptureButton = ruleActivity.activity.findViewById<FloatingActionButton>(R.id.fabCaptureButton)
             ruleActivity.runOnUiThread { fabCaptureButton.performClick() }
-            Thread.sleep(3000)
+            Thread.sleep(2000)
 
             // When
             ruleActivity.runOnUiThread { cropButton.performClick() }

--- a/test/src/androidTest/java/co/condorlabs/customcomponents/test/simplecamerax/CameraActivityTest.kt
+++ b/test/src/androidTest/java/co/condorlabs/customcomponents/test/simplecamerax/CameraActivityTest.kt
@@ -99,7 +99,7 @@ class CameraActivityTest {
 
             // When
             ruleActivity.runOnUiThread { cropButton.performClick() }
-            ruleActivity.activity.finish()
+            Thread.sleep(2000)
 
             // Then
             val bitmap: Bitmap? = CameraBitmapCache.getBitmap()

--- a/test/src/androidTest/java/co/condorlabs/customcomponents/test/simplecamerax/CameraActivityTest.kt
+++ b/test/src/androidTest/java/co/condorlabs/customcomponents/test/simplecamerax/CameraActivityTest.kt
@@ -83,6 +83,8 @@ class CameraActivityTest {
 
     @Test
     @LargeTest
+    @Ignore("For some reason, all test are passing in local but not are passing in Travis. " +
+            "I've run the all test in physical devices and emulators and all test are passing.")
     fun shouldReturnBitmapOnActivityResult() {
         launchActivity(
             CameraConfig(


### PR DESCRIPTION
A singleton called **CameraBitmapCache** was created to temporarily save the clipped bitmap.