### PR TITLE
Feature ➤ EditTextDateField

### DIFF
--- a/app/src/main/java/co/condorlabs/customcomponents/customedittext/EditTextDateField.kt
+++ b/app/src/main/java/co/condorlabs/customcomponents/customedittext/EditTextDateField.kt
@@ -44,14 +44,16 @@ class EditTextDateField(context: Context, attrs: AttributeSet) : BaseEditTextFor
     private var mSimpleDateFormat: SimpleDateFormat? = null
     private var mDateFormat = DEFAULT_DATE_FORMAT
     private var datePickerTheme: Int
+    private var openDatePickerOnTouch = false
 
     init {
         context.theme.obtainStyledAttributes(
             attrs,
             R.styleable.EditTextDateField,
             DEFAULT_STYLE_ATTR, DEFAULT_STYLE_RES
-        ).apply {
+        ).run {
             datePickerTheme = getResourceId(R.styleable.EditTextDateField_datePickerTheme, R.style.DatePickerTheme)
+            openDatePickerOnTouch = getBoolean(R.styleable.EditTextDateField_openDatePickerOnTouch, false)
 
             try {
                 mIconDrawable = getDrawable(R.styleable.EditTextDateField_picker_icon)
@@ -212,7 +214,7 @@ class EditTextDateField(context: Context, attrs: AttributeSet) : BaseEditTextFor
         this.editText?.setOnTouchListener { v, event ->
             when (event.action) {
                 MotionEvent.ACTION_UP -> {
-                    if (wasCalendarDrawableClicked(v, event)) {
+                    if (wasCalendarDrawableClicked(v, event) or openDatePickerOnTouch) {
                         val calendar = Calendar.getInstance()
 
                         val dialogCanBeOpenOnEditTextText = if (receiver.text?.isEmpty() == false) {

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -23,6 +23,7 @@
     <declare-styleable name="EditTextDateField">
         <attr name="picker_icon" format="integer" />
         <attr name="datePickerTheme" format="reference" />
+        <attr name="openDatePickerOnTouch" format="boolean" />
     </declare-styleable>
 
     <declare-styleable name="EditTextPhoneField">

--- a/bintray.gradle
+++ b/bintray.gradle
@@ -23,7 +23,7 @@ android {
 }
 
 ext {
-    libraryVersion = '1.1.6'
+    libraryVersion = '1.1.7'
 
     bintrayRepo = 'CustomComponents'
     bintrayName = 'CustomComponents'

--- a/test/src/androidTest/java/co/condorlabs/customcomponents/test/EditTextDateFieldTest.kt
+++ b/test/src/androidTest/java/co/condorlabs/customcomponents/test/EditTextDateFieldTest.kt
@@ -162,8 +162,9 @@ class EditTextDateFieldTest : MockActivityTest() {
         // When
         view.perform(click())
 
-        isTextDisplayed("ACEPTAR")
-        isTextDisplayed("CANCELAR")
+
+        isTextDisplayed("OK")
+        isTextDisplayed("CANCEL")
     }
 
     @SmallTest

--- a/test/src/androidTest/java/co/condorlabs/customcomponents/test/EditTextDateFieldTest.kt
+++ b/test/src/androidTest/java/co/condorlabs/customcomponents/test/EditTextDateFieldTest.kt
@@ -28,6 +28,7 @@ import co.condorlabs.customcomponents.*
 import co.condorlabs.customcomponents.customedittext.EditTextDateField
 import co.condorlabs.customcomponents.customedittext.ValueChangeListener
 import co.condorlabs.customcomponents.formfield.ValidationResult
+import co.condorlabs.customcomponents.test.util.isTextDisplayed
 import co.condorlabs.customcomponents.test.util.isTextNotDisplayed
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
@@ -145,6 +146,24 @@ class EditTextDateFieldTest : MockActivityTest() {
             ValidationResult(true, EMPTY),
             (ruleActivity.activity.findViewById<View>(R.id.tlDate) as? EditTextDateField)?.isValid()
         )
+    }
+
+    @SmallTest
+    @Test
+    fun shouldOpenDatePickerWhenUserTouchAnywhereOnComponent() {
+        MockActivity.layout = R.layout.activity_edittextdatefield_test
+        restartActivity()
+
+        // Given
+        val field = (ruleActivity.activity.findViewById<View>(R.id.tlDateWithOpenDatePickerOnTouch) as? EditTextDateField)
+        val realEditText = field!!.textInputLayout!!.editText!!
+        val view = onView(withId(realEditText.id))
+
+        // When
+        view.perform(click())
+
+        isTextDisplayed("ACEPTAR")
+        isTextDisplayed("CANCELAR")
     }
 
     @SmallTest

--- a/test/src/main/res/layout/activity_edittextdatefield_test.xml
+++ b/test/src/main/res/layout/activity_edittextdatefield_test.xml
@@ -1,12 +1,23 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
-              android:layout_width="match_parent" android:layout_height="match_parent">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <co.condorlabs.customcomponents.customedittext.EditTextDateField
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:id="@+id/tlDate"
-            app:hint="Expiration"
-            app:is_required="true"
-            app:picker_icon="@drawable/ic_date"/>
+        android:id="@+id/tlDate"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:hint="Expiration"
+        app:is_required="true"
+        app:picker_icon="@drawable/ic_date" />
+
+    <co.condorlabs.customcomponents.customedittext.EditTextDateField
+        android:id="@+id/tlDateWithOpenDatePickerOnTouch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:hint="Expiration"
+        app:is_required="true"
+        app:openDatePickerOnTouch="true"
+        app:picker_icon="@drawable/ic_date" />
 </LinearLayout>


### PR DESCRIPTION
### **openDatePickerOnTouch** property was added to **EditTextDateField** properties.

With this option the user can open the DatePicker by touching anywhere in the component
![ezgif com-gif-maker](https://user-images.githubusercontent.com/42741876/98991685-32f0d500-24fa-11eb-97d1-c9524a50f2b9.gif)
